### PR TITLE
feat: fallback to vanilla sprite loading

### DIFF
--- a/helpers/ResourceHelper.cs
+++ b/helpers/ResourceHelper.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.Networking;
 
@@ -28,6 +29,28 @@ namespace BerryLoaderNS
 					AudioClips.Add(key, DownloadHandlerAudioClip.GetContent(www));
 				}
 			}
+		}
+
+		public static Sprite LoadSprite(string modDir, string spriteName)
+		{
+			string path = Path.Combine(modDir, "Images", spriteName);
+
+			if (File.Exists(path))
+			{
+				var texture = new Texture2D(2, 2);
+				texture.LoadImage(File.ReadAllBytes(path));
+				return Sprite.Create(texture, new Rect(0, 0, texture.width, texture.height), Vector2.one / 2f);
+			}
+
+			var sprite = Resources.FindObjectsOfTypeAll<Sprite>().FirstOrDefault(i => i.name == spriteName);
+
+			if (sprite != null)
+			{
+				return sprite;
+			}
+
+			BerryLoader.L.LogError($"Failed to load sprite: {spriteName}");
+			return null;
 		}
 	}
 }

--- a/patches/DataLoader.cs
+++ b/patches/DataLoader.cs
@@ -53,9 +53,7 @@ namespace BerryLoaderNS
 							card.PickupSoundGroup = PickupSoundGroup.Custom;
 							WorldManager.instance.StartCoroutine(ResourceHelper.GetAudioClip(card.Id, Path.Combine(modDir, "Sounds", modcard.audio)));
 						}
-						var tex = new Texture2D(1024, 1024); // TODO: size?
-						tex.LoadImage(File.ReadAllBytes(Path.Combine(modDir, "Images", modcard.icon)));
-						card.Icon = Sprite.Create(tex, wood.Icon.rect, wood.Icon.pivot);
+						card.Icon = ResourceHelper.LoadSprite(modDir, modcard.icon);
 						card.MyCardType = EnumHelper.ToCardType(modcard.type);
 						card.gameObject.SetActive(false);
 						if (!modcard.script.Equals(""))
@@ -111,9 +109,7 @@ namespace BerryLoaderNS
 					mo.Name = modblueprint.nameOverride;
 					bp.NameTerm = modblueprint.nameTerm;
 					bp.Id = modblueprint.id;
-					var tex = new Texture2D(512, 512); // TODO: size?
-					tex.LoadImage(File.ReadAllBytes(Path.Combine(modDir, "Images", modblueprint.icon)));
-					bp.Icon = Sprite.Create(tex, wood.Icon.rect, wood.Icon.pivot);
+					bp.Icon = ResourceHelper.LoadSprite(modDir, modblueprint.icon);
 					bp.BlueprintGroup = EnumHelper.ToBlueprintGroup(modblueprint.group);
 					//bp.StackPostText = modblueprint.stackText; // gone?
 					bp.Subprints = new List<Subprint>();
@@ -173,9 +169,7 @@ namespace BerryLoaderNS
 					bpinst.gameObject.SetActive(false);
 					ModOverride mo = bpinst.gameObject.AddComponent<ModOverride>();
 					mo.Name = modbooster.name;
-					var tex = new Texture2D(1024, 1024); // TODO: size?
-					tex.LoadImage(File.ReadAllBytes(Path.Combine(modDir, "Images", modbooster.icon)));
-					bpinst.BoosterpackIcon = Sprite.Create(tex, humble.BoosterpackIcon.rect, humble.BoosterpackIcon.pivot);
+					bpinst.BoosterpackIcon = ResourceHelper.LoadSprite(modDir, modbooster.icon);
 					bpinst.BoosterId = modbooster.id;
 					bpinst.MinAchievementCount = modbooster.minAchievementCount;
 					bpinst.CardBags.Clear();


### PR DESCRIPTION
Currently the `icon` property only loads from the mods `Images` folder. This is fine in most cases but sometimes you want to reuse a vanilla texture.
The change tries to fallback to a vanilla icon when it has not been found inside the `Images` folder. It aims to work intuitive together with the current system and prevents distributing vanilla assets or effort to load the image afterwards manually.

Adding to this, it also allows for any sprite size, not only 1024x1024px and it logs a readable error message when the sprite has not been found. Because an icon is not mandatory by the game, an error log seems more preferable then an error throw.

Because modded cards are loaded after vanilla cards but before they get assigned to the GameDataLoader, `Resources.FindObjectsOfTypeAll` has to be used to find the sprites. This is a relatively costly operation but still faster then `tex.LoadImage` and `Sprite.Create` so performance is not an issue. Also it can be converted to a dictionary lookup later, if wanted.
